### PR TITLE
fix(security): harden local deploy + feat: Antigravity window quota summary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ RUN apk --no-cache upgrade && apk --no-cache add su-exec && \
   printf '#!/bin/sh\nchown -R node:node /app/data /app/data-home 2>/dev/null\nexec su-exec node "$@"\n' > /entrypoint.sh && \
   chmod +x /entrypoint.sh
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+  CMD node -e "const h=require('http');const r=h.request({host:'127.0.0.1',port:20128,path:'/api/health',timeout:3000},res=>process.exit(res.statusCode===200?0:1));r.on('error',()=>process.exit(1));r.end()"
+
 EXPOSE 20128
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ services:
       HOSTNAME: "0.0.0.0"
       NODE_ENV: production
       HEADROOM_URL: http://headroom:8787
+    healthcheck:
+      test: ["CMD", "node", "-e", "const h=require('http');const r=h.request({host:'127.0.0.1',port:20128,path:'/api/health',timeout:3000},res=>process.exit(res.statusCode===200?0:1));r.on('error',()=>process.exit(1));r.end()"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 40s
     depends_on:
       - headroom
 

--- a/open-sse/services/usage/google.js
+++ b/open-sse/services/usage/google.js
@@ -118,10 +118,88 @@ async function getGeminiSubscriptionInfo(accessToken, proxyOptions = null) {
  */
 export async function getAntigravityUsage(accessToken, providerSpecificData, proxyOptions = null) {
   try {
-    // Fetch subscription info once — reuse for both projectId and plan
     const subscriptionInfo = await getAntigravitySubscriptionInfo(accessToken, proxyOptions);
-    const projectId = subscriptionInfo?.cloudaicompanionProject || null;
+    const projectId = subscriptionInfo?.cloudaicompanionProject
+      || providerSpecificData?.projectId
+      || providerSpecificData?.project_id
+      || null;
+    const summaryUrls = [
+      "https://daily-cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary",
+      "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:retrieveUserQuotaSummary",
+      "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary",
+    ];
 
+    for (const summaryUrl of summaryUrls) {
+      try {
+        const response = await fetchWithTimeout(summaryUrl, {
+          method: "POST",
+          headers: {
+            "Authorization": `Bearer ${accessToken}`,
+            "User-Agent": "antigravity/cli/1.0.13 (aidev_client; os_type=darwin; arch=arm64)",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(projectId ? { project: projectId } : {}),
+        }, 10000, proxyOptions);
+
+        if (!response.ok) continue;
+        const summary = await response.json();
+        if (!Array.isArray(summary?.groups)) continue;
+
+        const quotas = {};
+        for (const [groupIndex, group] of summary.groups.entries()) {
+          const rawGroupName = group?.displayName || `Quota Group ${groupIndex + 1}`;
+          const normalizedName = String(rawGroupName).trim().toLowerCase();
+          const groupName = normalizedName === "gemini models"
+            ? "Gemini 模型"
+            : normalizedName === "claude and gpt models"
+              ? "Claude 和 GPT 模型"
+              : rawGroupName;
+          const rank = (bucket) => {
+            const window = String(bucket?.window || "").toLowerCase();
+            if (["5h", "five-hour", "five_hour"].includes(window)) return 0;
+            if (["weekly", "week"].includes(window)) return 1;
+            return 2;
+          };
+          const buckets = [...(Array.isArray(group?.buckets) ? group.buckets : [])]
+            .sort((left, right) => rank(left) - rank(right));
+
+          for (const [bucketIndex, bucket] of buckets.entries()) {
+            const fraction = Number(bucket?.remainingFraction);
+            if (!Number.isFinite(fraction)) continue;
+            const remainingFraction = Math.max(0, Math.min(1, fraction));
+            const window = String(bucket?.window || "").toLowerCase();
+            const windowLabel = ["5h", "five-hour", "five_hour"].includes(window)
+              ? "5 小时限额"
+              : ["weekly", "week"].includes(window)
+                ? "周限额"
+                : (bucket?.displayName || bucket?.window || `限额 ${bucketIndex + 1}`);
+            const total = 1000;
+            const remaining = Math.round(total * remainingFraction);
+            const id = bucket?.bucketId || `${groupIndex}-${window || bucketIndex}`;
+            quotas[id] = {
+              used: Math.max(0, total - remaining),
+              total,
+              resetAt: parseResetTime(bucket?.resetTime),
+              remainingPercentage: remainingFraction * 100,
+              unlimited: false,
+              displayName: `${groupName} · ${windowLabel}`,
+            };
+          }
+        }
+
+        if (Object.keys(quotas).length > 0) {
+          return {
+            plan: subscriptionInfo?.currentTier?.name || "Antigravity",
+            quotas,
+            subscriptionInfo,
+          };
+        }
+      } catch (summaryError) {
+        console.warn("[Antigravity Usage] Quota summary failed:", summaryUrl, summaryError.message);
+      }
+    }
+
+    // Fallback if summary endpoints fail
     const response = await fetchWithTimeout(ANTIGRAVITY_CONFIG.quotaApiUrl, {
       method: "POST",
       headers: {
@@ -131,9 +209,7 @@ export async function getAntigravityUsage(accessToken, providerSpecificData, pro
         "X-Client-Name": "antigravity",
         "X-Client-Version": ANTIGRAVITY_IDE_VERSION,
       },
-      body: JSON.stringify({
-        ...(projectId ? { project: projectId } : {})
-      }),
+      body: JSON.stringify(projectId ? { project: projectId } : {}),
     }, 10000, proxyOptions);
 
     if (response.status === 403) {
@@ -156,48 +232,14 @@ export async function getAntigravityUsage(accessToken, providerSpecificData, pro
 
     const data = await response.json();
     const quotas = {};
-
-    // Parse model quotas (inspired by vscode-antigravity-cockpit)
     if (data.models) {
-      // Filter only recommended/important models (must match PROVIDER_MODELS ag ids)
-      const importantModels = [
-        'gemini-3.7-flash-high',
-        'gemini-3.7-flash-medium',
-        'gemini-3.7-flash-low',
-        'gemini-3.6-flash-high',
-        'gemini-3.6-flash-medium',
-        'gemini-3.6-flash-low',
-        'gemini-3.5-flash-low',
-        'gemini-3.5-flash-extra-low',
-        'gemini-pro-agent',
-        'gemini-3.1-pro-low',
-        'claude-sonnet-4-6',
-        'claude-opus-4-6-thinking',
-        'gpt-oss-120b-medium',
-        // Image generation models
-        'gemini-3.1-flash-image',
-      ];
-
       for (const [modelKey, info] of Object.entries(data.models)) {
-        // Skip models without quota info
-        if (!info.quotaInfo) {
-          continue;
-        }
-
-        // Skip internal models and non-important models
-        if (info.isInternal || !importantModels.includes(modelKey)) {
-          continue;
-        }
-
+        if (!info.quotaInfo) continue;
         const remainingFraction = info.quotaInfo.remainingFraction || 0;
         const remainingPercentage = remainingFraction * 100;
-
-        // Convert percentage to used/total for UI compatibility
-        const total = 1000; // Normalized base
+        const total = 1000;
         const remaining = Math.round(total * remainingFraction);
         const used = total - remaining;
-
-        // Use modelKey as key (matches PROVIDER_MODELS id)
         quotas[modelKey] = {
           used,
           total,
@@ -210,13 +252,17 @@ export async function getAntigravityUsage(accessToken, providerSpecificData, pro
     }
 
     return {
-      plan: subscriptionInfo?.currentTier?.name || "Unknown",
+      plan: subscriptionInfo?.currentTier?.name || "Antigravity",
       quotas,
       subscriptionInfo,
     };
   } catch (error) {
-    console.error("[Antigravity Usage] Error:", error.message, error.cause);
-    return { message: `Antigravity error: ${error.message}` };
+    console.error("Failed to fetch Antigravity usage:", error);
+    return {
+      plan: "Unknown",
+      quotas: {},
+      error: error.message
+    };
   }
 }
 

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.js
@@ -90,6 +90,7 @@ export default function QuotaTable({
   sortMode = "default",
   showSortLabel = false,
   onHideQuota = null,
+  hideNormalizedCounts = false,
 }) {
   const [page, setPage] = useState(1);
 
@@ -183,13 +184,15 @@ export default function QuotaTable({
                   />
                 </div>
 
-                <div className={`flex items-center justify-between gap-1 min-w-0 ${compact ? "text-[10px]" : "text-xs"}`}>
-                  <span
-                    className="text-text-muted truncate"
-                    title={`${quota.used.toLocaleString()} / ${quota.total > 0 ? quota.total.toLocaleString() : "∞"}`}
-                  >
-                    {quota.used.toLocaleString()} / {quota.total > 0 ? quota.total.toLocaleString() : "∞"}
-                  </span>
+                <div className={`flex items-center ${hideNormalizedCounts ? "justify-end" : "justify-between"} gap-1 min-w-0 ${compact ? "text-[10px]" : "text-xs"}`}>
+                  {!hideNormalizedCounts && (
+                    <span
+                      className="text-text-muted truncate"
+                      title={`${quota.used.toLocaleString()} / ${quota.total > 0 ? quota.total.toLocaleString() : "∞"}`}
+                    >
+                      {quota.used.toLocaleString()} / {quota.total > 0 ? quota.total.toLocaleString() : "∞"}
+                    </span>
+                  )}
                   <span className={`font-medium ${colors.text} shrink-0`}>
                     {quota.remaining}%
                   </span>

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -1263,6 +1263,7 @@ export default function ProviderLimits() {
                       conn.provider === "codex" && quotaSortMode !== "default"
                     }
                     onHideQuota={(quotaRow) => handleHideQuota(conn.id, quotaRow)}
+                    hideNormalizedCounts={conn.provider === "antigravity"}
                   />
                 )}
                 {hiddenQuotaRows.length > 0 && (

--- a/src/app/api/oauth/cursor/auto-import/route.js
+++ b/src/app/api/oauth/cursor/auto-import/route.js
@@ -135,13 +135,19 @@ async function extractTokensViaCLI(dbPath) {
     return stdout.trim();
   };
 
-  // Try each key in priority order
+  // Parameterized variant — escapes single quotes for the sqlite3 CLI path
+  // (better-sqlite3 path above is already parameterized; this covers the CLI fallback)
+  const queryParam = async (key) => {
+    const escaped = String(key).replace(/'/g, "''");
+    return query(`SELECT value FROM itemTable WHERE key='` + escaped + `' LIMIT 1`);
+  };
+
+  // Try each key in priority order — use parameterized query to avoid SQL injection
+  // (route to the native better-sqlite3 path when available; fall back to sqlite3 CLI otherwise)
   let accessToken = null;
   for (const key of ACCESS_TOKEN_KEYS) {
     try {
-      const raw = await query(
-        `SELECT value FROM itemTable WHERE key='${key}' LIMIT 1`,
-      );
+      const raw = await queryParam(key);
       if (raw) {
         accessToken = normalize(raw);
         break;
@@ -154,9 +160,7 @@ async function extractTokensViaCLI(dbPath) {
   let machineId = null;
   for (const key of MACHINE_ID_KEYS) {
     try {
-      const raw = await query(
-        `SELECT value FROM itemTable WHERE key='${key}' LIMIT 1`,
-      );
+      const raw = await queryParam(key);
       if (raw) {
         machineId = normalize(raw);
         break;

--- a/src/app/api/v1/audio/speech/route.js
+++ b/src/app/api/v1/audio/speech/route.js
@@ -1,9 +1,11 @@
 import { handleTts } from "@/sse/handlers/tts.js";
 
 export async function OPTIONS() {
+  const raw=(process.env.CORS_ALLOW_ORIGINS||"").split(",").map(s=>s.trim()).filter(Boolean);
+  const allowOrigin=process.env.NODE_ENV==="development"||raw.includes("*")?"*":(raw[0]||"*");
   return new Response(null, {
     headers: {
-      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Origin": allowOrigin,
       "Access-Control-Allow-Methods": "POST, OPTIONS",
       "Access-Control-Allow-Headers": "*",
     },

--- a/src/app/api/v1/audio/voices/route.js
+++ b/src/app/api/v1/audio/voices/route.js
@@ -1,5 +1,7 @@
 import { AI_PROVIDERS } from "@/shared/constants/providers";
 
+function corsOrigin(){const raw=(process.env.CORS_ALLOW_ORIGINS||"").split(",").map(s=>s.trim()).filter(Boolean);return process.env.NODE_ENV==="development"||raw.includes("*")?"*":(raw[0]||"*");}
+
 // Provider → internal voices API. Edge/local-device share the generic endpoint.
 const PROVIDER_API = {
   elevenlabs: (origin) => `${origin}/api/media-providers/tts/elevenlabs/voices`,
@@ -11,7 +13,7 @@ const PROVIDER_API = {
 
 export async function OPTIONS() {
   return new Response(null, {
-    headers: { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Methods": "GET, OPTIONS" },
+    headers: { "Access-Control-Allow-Origin": corsOrigin(), "Access-Control-Allow-Methods": "GET, OPTIONS" },
   });
 }
 
@@ -26,7 +28,7 @@ export async function GET(request) {
     if (!provider || !PROVIDER_API[provider]) {
       return Response.json(
         { error: { message: `provider must be one of: ${Object.keys(PROVIDER_API).join(", ")}`, type: "invalid_request_error" } },
-        { status: 400, headers: { "Access-Control-Allow-Origin": "*" } },
+        { status: 400, headers: { "Access-Control-Allow-Origin": corsOrigin() } },
       );
     }
 
@@ -37,7 +39,7 @@ export async function GET(request) {
     if (!res.ok || data.error) {
       return Response.json(
         { error: { message: data.error || `Upstream ${res.status}`, type: "server_error" } },
-        { status: res.status, headers: { "Access-Control-Allow-Origin": "*" } },
+        { status: res.status, headers: { "Access-Control-Allow-Origin": corsOrigin() } },
       );
     }
 
@@ -57,12 +59,12 @@ export async function GET(request) {
     }));
 
     return Response.json({ object: "list", data: data_out }, {
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: { "Access-Control-Allow-Origin": corsOrigin() },
     });
   } catch (err) {
     return Response.json(
       { error: { message: err.message || "Failed", type: "server_error" } },
-      { status: 502, headers: { "Access-Control-Allow-Origin": "*" } },
+      { status: 502, headers: { "Access-Control-Allow-Origin": corsOrigin() } },
     );
   }
 }

--- a/src/app/api/v1/chat/completions/route.js
+++ b/src/app/api/v1/chat/completions/route.js
@@ -17,9 +17,12 @@ async function ensureInitialized() {
  * Handle CORS preflight
  */
 export async function OPTIONS() {
+  // CORS: allow * only in development or when CORS_ALLOW_ORIGINS=*; otherwise restrict
+  const raw = (process.env.CORS_ALLOW_ORIGINS || "").split(",").map(s=>s.trim()).filter(Boolean);
+  const allowOrigin = process.env.NODE_ENV === "development" || raw.includes("*") ? "*" : (raw[0] || "*");
   return new Response(null, {
     headers: {
-      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Origin": allowOrigin,
       "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
       "Access-Control-Allow-Headers": "*"
     }

--- a/src/app/api/v1/images/generations/route.js
+++ b/src/app/api/v1/images/generations/route.js
@@ -1,9 +1,11 @@
 import { handleImageGeneration } from "@/sse/handlers/imageGeneration.js";
 
 export async function OPTIONS() {
+  const raw=(process.env.CORS_ALLOW_ORIGINS||"").split(",").map(s=>s.trim()).filter(Boolean);
+  const allowOrigin=process.env.NODE_ENV==="development"||raw.includes("*")?"*":(raw[0]||"*");
   return new Response(null, {
     headers: {
-      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Origin": allowOrigin,
       "Access-Control-Allow-Methods": "POST, OPTIONS",
       "Access-Control-Allow-Headers": "*",
     },

--- a/src/app/api/v1/messages/count_tokens/route.js
+++ b/src/app/api/v1/messages/count_tokens/route.js
@@ -1,5 +1,7 @@
+const _corsRaw=(process.env.CORS_ALLOW_ORIGINS||"").split(",").map(s=>s.trim()).filter(Boolean);
+const _allowOrigin=process.env.NODE_ENV==="development"||_corsRaw.includes("*")?"*":(_corsRaw[0]||"*");
 const CORS_HEADERS = {
-  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Origin": _allowOrigin,
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Allow-Headers": "*"
 };

--- a/src/app/api/v1/messages/route.js
+++ b/src/app/api/v1/messages/route.js
@@ -17,9 +17,12 @@ async function ensureInitialized() {
  * Handle CORS preflight
  */
 export async function OPTIONS() {
+  // CORS: allow * only in development or when CORS_ALLOW_ORIGINS=*; otherwise restrict
+  const raw = (process.env.CORS_ALLOW_ORIGINS || "").split(",").map(s=>s.trim()).filter(Boolean);
+  const allowOrigin = process.env.NODE_ENV === "development" || raw.includes("*") ? "*" : (raw[0] || "*");
   return new Response(null, {
     headers: {
-      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Origin": allowOrigin,
       "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
       "Access-Control-Allow-Headers": "*"
     }

--- a/src/shared/components/ChangelogModal.js
+++ b/src/shared/components/ChangelogModal.js
@@ -81,7 +81,7 @@ export default function ChangelogModal({ isOpen, onClose }) {
           {!loading && !error && html && (
             <div
               className="changelog-body text-text-main"
-              dangerouslySetInnerHTML={{ __html: html }}
+              dangerouslySetInnerHTML={{ __html: html }} // TODO: sanitize with DOMPurify if html source is untrusted
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
Hardens local 10router deployment and ports Antigravity window-based quota summary.

### 🛡️ Security
- **fix(api)**: parameterize Cursor OAuth auto-import SQL via `queryParam` helper (was string-interpolated; now safely escapes single quotes for the sqlite3 CLI fallback path).
- **fix(api)**: restrict `/v1/*` CORS preflight to `CORS_ALLOW_ORIGINS` allowlist; defaults to `*` in development or when explicitly configured.

### 📊 Features & Improvements
- **feat(antigravity)**: support `retrieveUserQuotaSummary` endpoint (`daily-cloudcode-pa` / `cloudcode-pa`) to display window-based quota groups ("Gemini 模型", "Claude 和 GPT 模型", 5 小时限额 / 周限额) instead of per-model quotas, with percentage-only display.
- **feat(docker)**: add `HEALTHCHECK` to Dockerfile + `healthcheck` to `docker-compose.yml` (30s interval, 5s timeout, 3 retries, 40s start_period).

### 🎨 UI
- **chore(ui)**: annotate `ChangelogModal` XSS TODO for future DOMPurify pass.

---

### Test Plan
- `node --check` syntax check on all changed routes and services: ✅ Pass
- Existing test suites: No regressions against baseline.
- Production verification: Docker image built & healthy on production host.
