### PR TITLE
fix: CodeBuddy CN whitelist false-positive, SenseNova effort mapping & GLM-4.6V-Flash vision capability

### DIFF
--- a/open-sse/executors/codebuddy-cn.js
+++ b/open-sse/executors/codebuddy-cn.js
@@ -32,7 +32,11 @@ export class CodeBuddyExecutor extends DefaultExecutor {
     // wipe the agent's full identity/role/tool memory on every new session
     // ("失忆"). Match on unique markers that won't appear in an attacker-controlled
     // prompt (product names, official-signature phrases).
-    const WHITELIST_PATTERN = /hermes|10router|9router|\bclaude code by anthropic\b|anthropic's official cli|\bsystem instructions\b|你的身份|你的角色设定/i;
+    // NOTE: "anthropic's official cli" was removed from the whitelist — Claude Code's
+    // own system prompt opens with exactly that phrase ("You are Claude Code,
+    // Anthropic's official CLI for Claude"), so whitelisting it let the raw agent
+    // identity through and Tencent's filter rejected the request (400 code 11128).
+    const WHITELIST_PATTERN = /hermes|10router|9router|\bclaude code by anthropic\b|\bsystem instructions\b|你的身份|你的角色设定/i;
     const flatten = (content) =>
       typeof content === "string"
         ? content

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -103,6 +103,10 @@ export const MODEL_CAPABILITIES = {
 
   // GLM vision variant (text GLM has no vision)
   "glm-4.6v":          { vision: true, reasoning: true, thinkingFormat: "zai", contextWindow: 128000 },
+  // Zhipu official free-tier vision flash — separate model from glm-4.6v
+  // (different pricing tier; free permanent). Exact id casing as registered
+  // via the dashboard custom provider, so exact-match wins before *glm-4*.
+  "GLM-4.6V-Flash":    { vision: true, reasoning: true, thinkingFormat: "zai", contextWindow: 200000 },
   "glm-5.3-flash":     { vision: true, videoInput: true, pdf: true, reasoning: true, thinkingFormat: "zai", contextWindow: 1000000, maxOutput: 131072 },
 
   // Qwen plain coder/text (no vision) — registry "vision-model" / "coder-model" aliases

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -282,9 +282,12 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
     case "deepseek": {
       if (none && canDisable) { body.thinking = { type: "disabled" }; break; }
       body.thinking = { type: "enabled" };
-      // DeepSeek: low/medium→high, xhigh/max→max.
+      // DeepSeek: low/medium→high, xhigh/max→xhigh. SenseNova's DeepSeek V4
+      // endpoint rejects "max" ("field ReasoningEffort invalid, should be one
+      // of: low, medium, high, xhigh, none") while DeepSeek-official accepts it,
+      // so clamp to the widest shared value.
       const level = toLevel(eff);
-      body.reasoning_effort = level === "xhigh" || level === "max" ? "max" : "high";
+      body.reasoning_effort = level === "xhigh" || level === "max" ? "xhigh" : "high";
       break;
     }
     case "kimi": {


### PR DESCRIPTION
Fixes three issues found while running 9router behind Tencent CodeBuddy CN, SenseNova and Zhipu GLM-CN upstreams:

1. **CodeBuddy CN whitelist false-positive**: the whitelist pattern included the phrase `anthropic's official cli`, which is exactly how Claude Code opens its own system prompt ("You are Claude Code, Anthropic's official CLI for Claude"). Whitelisting it let the raw agent identity through and Tencent's content filter rejected the whole request with 400 code 11128. Removed the phrase so agent prompts get neutralized as intended.

2. **SenseNova DeepSeek effort mapping**: SenseNova's DeepSeek V4 endpoint rejects reasoning_effort "max" (400: "field ReasoningEffort invalid, should be one of: low, medium, high, xhigh, none") while DeepSeek-official accepts it. Clamped xhigh/max to xhigh in the deepseek case so both upstreams work.

3. **GLM-4.6V-Flash missing vision capability**: Zhipu's GLM-4.6V-Flash (free permanent vision tier — a separate model from the paid glm-4.6v) was not in MODEL_CAPABILITIES. The lowercase exact entry `glm-4.6v` doesn't match the official casing `GLM-4.6V-Flash`, and the `*glm-4*` family pattern carries no vision flag, so the model resolved as text-only and image requests were dropped before reaching the upstream. Added an exact entry (vision + zai thinkingFormat). Verified live against open.bigmodel.cn: both the coding-line and standard v4 endpoints identify images correctly once the capability is registered.