### PR TITLE
Fix: 非流式请求（省略 stream 字段）被误判为流式，返回畸形 SSE — 实验性开关 strictStreamDefault (#4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 > 面向用户的精简更新见 [`public/i18n/changelog/`](https://github.com/techysy/10router/tree/main/public/i18n/changelog)（`en.md` / `zh-CN.md` / `zh-TW.md`，仪表盘「Change Log」按界面语言加载对应文件）。本文件为完整开发日志，按版本从上往下排列。
 
+## v1.0.7 (TBD)
+
+> Issue #4 修复：非流式请求（省略 stream 字段）被误判为流式。行为翻转放在实验性开关 `strictStreamDefault` 后面（默认关 = 保持上游兼容行为），避免对省略 stream 却期待 SSE 的存量客户端造成静默破坏。
+
+### 🐛 修复
+
+- **非流式请求（省略 stream 字段）被误判为流式，返回畸形 SSE 响应（issue #4，用户反馈）**：`chatCore.js` 的默认流式判定 `body.stream !== false` 在字段省略时恒为真 → 按 OpenAI 规范应返回 `application/json` 的请求实际返回 `text/event-stream` + 尾部 `data: [DONE]`，官方 SDK / curl 等严格 JSON 客户端解析失败（1.0.3 起即存在；上游 9router 同逻辑，master 未修）。判定抽为纯函数 `open-sse/utils/streamDefault.js` `resolveStreamDefault`，新设置键 `strictStreamDefault`（默认 false 保持现状；true 时省略 = 非流式，规范语义）经 `src/sse/handlers/chat.js` 传入 `handleChatCore`，Profile → 实验性功能新增开关（三语词条）；`forceStream` 供应商（openai / codex / codebuddy 等 7 个）、Accept 头回退与 deepseek-tui 分支在两档下行为不变。新增单测 `tests/unit/stream-default.test.js` 锁定两档行为。
+
 ## v1.0.6 (2026-09-05)
 
 > v1.0.5（2026-09-03，含最后一次 tag 移动并入的 APInex / 用量表修复 / 上游 v0.5.65 同步）之后的新增功能版：CodeBuddy CN 每日自动签到、Antigravity Gemini 3.8 Flash 修复 + 配额对齐官网（5h+每周）、OpenCode Free 免费目录对齐、Windows Web 安装器、quota「只看有余额」实时重算、更新横幅与 Profile i18n 补齐。

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Architecture and engineering notes for the 10Router gateway + dashboard. All doc
 - [Model JSON Catalog Mechanism](/docs/en/json-model-catalog-mechanism.md) — `modelsJsonUrl` online model catalogs, Gitee fallback, and the "enabled but not listed" pitfall.
 - [MITM Proxy Security Hardening](/docs/en/mitm-security-hardening.md) — the four security fixes (TLS verification, 0600 root CA key, no blind port-443 kill, hosts cleanup).
 - [Mirasim-bundled dsh tool_call id/name loss](/docs/en/mirasim-dsh-toolcall-loss.md) — third-party bug causing 11133/`unknown tool ""`; 10Router does not work around it.
+- [Stream-default spec fix (issue #4)](/docs/en/stream-default-spec-fix.md) — omitted `stream` was misjudged as streaming; experimental `strictStreamDefault` toggle restores the OpenAI-spec default.
 
 ### CodeBuddy CN compatibility layers
 
@@ -42,6 +43,7 @@ Architecture and engineering notes for the 10Router gateway + dashboard. All doc
 - [模型 JSON 目录机制](/docs/zh-CN/json-model-catalog-mechanism.md) — `modelsJsonUrl` 在线模型目录、Gitee 回退，以及"激活了却不显示"的坑。
 - [MITM 代理安全加固](/docs/zh-CN/mitm-security-hardening.md) — 四项安全修复（TLS 校验、root CA 私钥 0600、不再盲杀 443、hosts 清理）。
 - [Mirasim 内嵌 dsh 工具调用 id/name 丢失](/docs/zh-CN/mirasim-dsh-toolcall-loss.md) — 第三方 bug 导致 11133 / `unknown tool ""`，10Router 不做适配。
+- [stream 默认值规范修复（issue #4）](/docs/zh-CN/stream-default-spec-fix.md) — 省略 `stream` 被误判为流式；实验性开关 `strictStreamDefault` 恢复 OpenAI 规范默认。
 
 ### CodeBuddy CN 兼容层
 

--- a/docs/en/stream-default-spec-fix.md
+++ b/docs/en/stream-default-spec-fix.md
@@ -1,0 +1,84 @@
+# Non-streaming requests (omitted `stream` field) misjudged as streaming — fix & experimental toggle
+
+> Fixed: 2026-09-05 · Issue: [#4](https://github.com/techysy/10router/issues/4) · PR: [#6](https://github.com/techysy/10router/pull/6)
+> Affected versions: v1.0.3 onward (inherited from upstream 9router, whose master is still unfixed); the fix ships with v1.0.7
+
+## Background
+
+A user reported connection/parse errors when calling 10Router's `/v1/chat/completions` through **WorkBuddy** (an OpenAI-compatible client); curl reproduces it too. The request body **omits the `stream` field** — per the OpenAI spec, an omitted `stream` means non-streaming, and the server must return `application/json`.
+
+Instead, 10Router returned `content-type: text/event-stream` with a JSON body followed by a trailing `data: [DONE]` line. Strict JSON parsers (official SDKs, `curl | jq`, …) fail on it.
+
+## Root cause
+
+The streaming decision in `open-sse/handlers/chatCore.js`:
+
+```js
+// before the fix (chatCore.js:115)
+let stream = providerRequiresStreaming ? true : (body.stream !== false);
+```
+
+When `stream` is omitted, `body.stream` is `undefined`, and `undefined !== false` is always `true` → **streaming by default**, the opposite of the OpenAI spec (omitted = non-streaming).
+
+There is an Accept-header fallback (explicit `Accept: application/json` forces non-streaming), but official SDKs and curl send `Accept: */*`, so it never fires.
+
+The logic was inherited from upstream 9router (merged in during the `fd7a881c` history rewrite); upstream master still has the same line.
+
+## The fix: experimental toggle `strictStreamDefault`
+
+Flipping the default unconditionally would **silently break** legacy clients that omit `stream` yet parse the response as SSE (a historically common lenient usage). So the fix ships behind an experimental toggle, **default OFF = current behavior preserved**:
+
+| `strictStreamDefault` | Omitted `stream` | Semantics |
+|----------------------|------------------|-----------|
+| `false` (default) | streaming (SSE) | upstream-compatible behavior; zero impact on legacy clients |
+| `true` | **non-streaming (JSON)** | OpenAI-spec behavior (the issue #4 ask) |
+
+Explicit `stream: true` / `stream: false` behave identically in both modes.
+
+### Implementation
+
+The decision is extracted into a pure function `open-sse/utils/streamDefault.js` (matching the open-sse convention: config-driven, unit-testable logic):
+
+```js
+export function resolveStreamDefault({ bodyStream, providerRequiresStreaming, strictStreamDefault }) {
+  if (providerRequiresStreaming) return true;
+  return strictStreamDefault === true ? bodyStream === true : bodyStream !== false;
+}
+```
+
+Plumbing (the open-sse engine never touches the DB — module boundary preserved):
+
+```
+settingsRepo.DEFAULT_SETTINGS.strictStreamDefault (default false)
+  → GET/PATCH /api/settings (no whitelist; new key persists automatically)
+  → src/sse/handlers/chat.js reads chatSettings.strictStreamDefault
+  → handleChatCore({ ..., strictStreamDefault })
+  → resolveStreamDefault(...)
+```
+
+UI: Profile → Experimental gains an “OpenAI-spec stream default” toggle (zh-CN / zh-TW literals added).
+
+### Behavior unchanged in both modes
+
+- **`forceStream` providers** (7 registered: openai / codex / codebuddy-cn / codebuddy-intl / commandcode / grok-cli / zed): always stream regardless of the toggle and the request field — those upstreams only support streaming.
+- **Accept-header fallback**: explicit `Accept: application/json` still forces non-streaming.
+- **deepseek-tui non-interactive branch** and **image-generation forced-non-streaming branch**: evaluated after `resolveStreamDefault`, untouched.
+- **Internal callers** (model ping, provider tests) already send `stream: false` explicitly — zero impact.
+
+## Verification
+
+Unit test `tests/unit/stream-default.test.js` (7 cases) locks the truth table for both modes:
+
+```
+legacy:  omitted → stream · true → stream · false → non-stream
+strict:  omitted → non-stream · true → stream · false → non-stream
+forceStream: both modes × all inputs → always stream
+```
+
+Equivalent verification from the issue reporter: patching the compiled bundle in 4 places (`!1!==x.stream` → `!0===x.stream`, i.e. strict-mode semantics) made both streaming and non-streaming calls work in WorkBuddy.
+
+## Notes
+
+1. **Known upstream leftover (unfixed, P2)**: streaming requests with a `tools` parameter emit **two** `data: [DONE]` markers at the end. SDKs stop parsing at the first one, so it is not fatal; independent of this fix, left for later.
+2. **The toggle is global**: `strictStreamDefault` applies to all non-`forceStream` providers' `/v1/chat/completions` traffic; there is no per-provider granularity.
+3. **If upstream ever fixes the default**: the legacy branch of `resolveStreamDefault` can be removed wholesale and the toggle retired.

--- a/docs/zh-CN/stream-default-spec-fix.md
+++ b/docs/zh-CN/stream-default-spec-fix.md
@@ -1,0 +1,84 @@
+# 非流式请求（省略 stream 字段）被误判为流式 — 修复与实验性开关
+
+> 修复日期：2026-09-05 · 关联 issue：[#4](https://github.com/techysy/10router/issues/4) · PR：[#6](https://github.com/techysy/10router/pull/6)
+> 影响版本：v1.0.3 起（上游 9router 继承逻辑，上游 master 同样未修）；修复随 v1.0.7 发布
+
+## 背景
+
+用户通过 **WorkBuddy**（OpenAI 兼容客户端）调用 10Router 的 `/v1/chat/completions` 时报连接/解析错误，curl 亦可复现。请求体**省略 `stream` 字段**——按 OpenAI 规范，省略即默认非流式，应返回 `application/json`。
+
+实际返回却是 `content-type: text/event-stream`，body 为一段 JSON 再拼一行 `data: [DONE]`。严格的 JSON 解析器（官方 SDK、curl + jq 等）直接报错。
+
+## 根因
+
+`open-sse/handlers/chatCore.js` 的流式判定：
+
+```js
+// 修复前（chatCore.js:115）
+let stream = providerRequiresStreaming ? true : (body.stream !== false);
+```
+
+`stream` 字段省略时 `body.stream` 为 `undefined`，而 `undefined !== false` 恒为 `true` → **默认走流式**，与 OpenAI 规范（省略 = 非流式）相反。
+
+代码里有一个 Accept 头回退（客户端显式 `Accept: application/json` 时强制非流式），但官方 SDK 与 curl 发送的是 `Accept: */*`，回退永远不触发。
+
+该逻辑由上游 9router 继承而来（`fd7a881c` 历史重塑时并入），上游 master 至今同样未修。
+
+## 修复：实验性开关 `strictStreamDefault`
+
+直接翻转默认值会**静默破坏**一类存量客户端：省略 `stream` 但实际按 SSE 解析的宽松实现（历史上不少客户端依赖此行为）。因此修复放在实验性开关后面，**默认关闭 = 保持现状**：
+
+| `strictStreamDefault` | 省略 `stream` 时 | 语义 |
+|----------------------|-----------------|------|
+| `false`（默认） | 流式（SSE） | 上游兼容行为，存量客户端零感知 |
+| `true` | **非流式（JSON）** | OpenAI 规范行为（issue #4 诉求） |
+
+显式 `stream: true` / `stream: false` 在两档下行为完全一致。
+
+### 实现
+
+判定抽为纯函数 `open-sse/utils/streamDefault.js`（符合 open-sse「配置驱动、逻辑可单测」的约定）：
+
+```js
+export function resolveStreamDefault({ bodyStream, providerRequiresStreaming, strictStreamDefault }) {
+  if (providerRequiresStreaming) return true;
+  return strictStreamDefault === true ? bodyStream === true : bodyStream !== false;
+}
+```
+
+传参链（open-sse 引擎不碰 DB，保持模块边界）：
+
+```
+settingsRepo.DEFAULT_SETTINGS.strictStreamDefault (默认 false)
+  → GET/PATCH /api/settings（无白名单，新键自动持久化）
+  → src/sse/handlers/chat.js 读 chatSettings.strictStreamDefault
+  → handleChatCore({ ..., strictStreamDefault })
+  → resolveStreamDefault(...)
+```
+
+UI：Profile → 实验性功能 新增「OpenAI-spec stream default」开关（zh-CN / zh-TW 词条已补）。
+
+### 两档下均不变的行为
+
+- **`forceStream` 供应商**（openai / codex / codebuddy-cn / codebuddy-intl / commandcode / grok-cli / zed 共 7 个注册了 `forceStream: true`）：无论开关与请求字段，一律流式——这些上游只支持流式。
+- **Accept 头回退**：显式 `Accept: application/json` 仍强制非流式。
+- **deepseek-tui 非交互分支**、**图像生成模型强制非流式分支**：判定顺序在 `resolveStreamDefault` 之后，行为不变。
+- **内部调用方**（模型 ping、供应商测试）本就显式传 `stream: false`，零影响。
+
+## 验证
+
+单测 `tests/unit/stream-default.test.js`（7 用例）锁定两档真值表：
+
+```
+legacy 档: 省略→流式 · true→流式 · false→非流式
+strict 档: 省略→非流式 · true→流式 · false→非流式
+forceStream: 两档 × 全部输入 → 恒流式
+```
+
+issue 报告者的等价验证：对编译产物做 4 处 `!1!==x.stream` → `!0===x.stream` 临时补丁（即 strict 档语义），WorkBuddy 流式 + 非流式均恢复正常。
+
+## 相关注意事项
+
+1. **上游残留问题（未修，P2）**：流式请求带 `tools` 参数时，SSE 尾部会发**两个** `data: [DONE]`。SDK 在第一个即停止解析，不致命；与本修复独立，留待后续。
+2. **开关是全局的**：`strictStreamDefault` 作用于所有非 `forceStream` 供应商的 `/v1/chat/completions` 流量，无按供应商粒度。
+3. **未来若上游修复默认值**：`resolveStreamDefault` 的 legacy 分支可整体移除，开关退役。

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -30,6 +30,7 @@ import { stripUnsupportedModalities } from "../translator/concerns/modality.js";
 import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
 import { isFreeModel, formatFreeRateLimitMessage } from "../utils/freeModel.js";
+import { resolveStreamDefault } from "../utils/streamDefault.js";
 
 /**
  * Core chat handler - shared between SSE and Worker
@@ -58,7 +59,7 @@ export function stripContinuityFields(body) {
   return body;
 }
 
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking, strictStreamDefault }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
   // Stable per-session color so all lines of one CLI conversation share a tag
@@ -112,7 +113,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const clientRequestedStreaming = body.stream === true || sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI;
   const providerRequiresStreaming = PROVIDERS[provider]?.forceStream === true;
-  let stream = providerRequiresStreaming ? true : (body.stream !== false);
+  // Issue #4: omitted `stream` historically meant streaming (upstream legacy).
+  // strictStreamDefault (experimental toggle) restores the OpenAI-spec default
+  // (omitted = non-streaming JSON); forceStream providers and the Accept-header
+  // fallback below keep working in both modes.
+  let stream = resolveStreamDefault({ bodyStream: body.stream, providerRequiresStreaming, strictStreamDefault });
 
   // Image generation models require non-streaming (Google v1internal:generateContent)
   const modelType = getModelType(alias, model);

--- a/open-sse/utils/streamDefault.js
+++ b/open-sse/utils/streamDefault.js
@@ -1,0 +1,26 @@
+/**
+ * Streaming-default resolution for /v1/chat/completions.
+ *
+ * OpenAI spec: an omitted `stream` field means NON-streaming (JSON response).
+ * The upstream engine historically defaulted to streaming
+ * (`body.stream !== false` — `undefined !== false` is true), which breaks
+ * strict JSON parsers (official SDKs, curl) with a malformed
+ * `text/event-stream` body; see issue #4.
+ *
+ * Flipping the default unconditionally would silently change behavior for
+ * legacy clients that omit `stream` and expect SSE, so it ships behind the
+ * experimental `strictStreamDefault` toggle (default off = legacy behavior).
+ */
+
+/**
+ * Resolve the effective streaming decision from the request's `stream` field.
+ * @param {object} p
+ * @param {boolean|undefined} p.bodyStream - the raw `body.stream` value (may be undefined)
+ * @param {boolean} p.providerRequiresStreaming - provider registry `forceStream` flag
+ * @param {boolean} p.strictStreamDefault - experimental spec-compliant toggle
+ * @returns {boolean} true = stream (SSE), false = non-streaming (JSON)
+ */
+export function resolveStreamDefault({ bodyStream, providerRequiresStreaming, strictStreamDefault }) {
+  if (providerRequiresStreaming) return true;
+  return strictStreamDefault === true ? bodyStream === true : bodyStream !== false;
+}

--- a/public/i18n/literals/zh-CN.json
+++ b/public/i18n/literals/zh-CN.json
@@ -1488,6 +1488,8 @@
   "Enter your current password to export CodeBuddy CN accounts.": "输入当前密码以导出 CodeBuddy CN 账号。",
   "Enter your current password to import CodeBuddy CN accounts.": "输入当前密码以导入 CodeBuddy CN 账号。",
   "CodeBuddy CN auto daily check-in": "CodeBuddy CN 每日自动签到",
+  "OpenAI-spec stream default": "OpenAI 规范 stream 默认",
+  "Treat an omitted stream field as non-streaming (issue #4). Off = legacy upstream behavior (omitted = streaming)": "省略 stream 字段时按 OpenAI 规范返回非流式 JSON（issue #4）。关闭 = 沿用上游行为（省略 = 流式）",
   "Automatically check in CodeBuddy CN accounts once a day (random 00:00–06:00 local)": "每天为 CodeBuddy CN 账号自动签到一次（本地时间 00:00–06:00 随机时段）",
   "When enabled, the Import / Export buttons on the CodeBuddy CN page are replaced": "启用后 CodeBuddy CN 页面的 Import / Export 按钮将被替换",
   "Check in now": "立即签到",

--- a/public/i18n/literals/zh-TW.json
+++ b/public/i18n/literals/zh-TW.json
@@ -304,5 +304,7 @@
   "accounts exported": "個帳號已匯出",
   "Export failed": "匯出失敗",
   "Enter your current password to export CodeBuddy CN accounts.": "輸入目前密碼以匯出 CodeBuddy CN 帳號。",
-  "Enter your current password to import CodeBuddy CN accounts.": "輸入目前密碼以匯入 CodeBuddy CN 帳號。"
+  "Enter your current password to import CodeBuddy CN accounts.": "輸入目前密碼以匯入 CodeBuddy CN 帳號。",
+  "OpenAI-spec stream default": "OpenAI 規範 stream 預設",
+  "Treat an omitted stream field as non-streaming (issue #4). Off = legacy upstream behavior (omitted = streaming)": "省略 stream 欄位時依 OpenAI 規範回傳非串流 JSON（issue #4）。關閉 = 沿用上游行為（省略 = 串流）"
 }

--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -186,6 +186,23 @@ export default function ProfilePage() {
     }
   };
 
+  const toggleStrictStreamDefault = async () => {
+    const next = !(settings.strictStreamDefault === true);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ strictStreamDefault: next }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setSettings((prev) => ({ ...prev, ...data }));
+      }
+    } catch (error) {
+      console.log("Error toggling strict stream default:", error);
+    }
+  };
+
   useEffect(() => {
     fetch("/api/settings")
       .then((res) => res.json())
@@ -1778,6 +1795,20 @@ export default function ProfilePage() {
               <Toggle
                 checked={settings.codeBuddyCheckin === true}
                 onChange={toggleCodeBuddyCheckin}
+              />
+            </div>
+
+            {/* OpenAI-spec stream default (issue #4): omitted stream = non-streaming */}
+            <div className="flex items-start sm:items-center justify-between gap-4 pt-4 border-t border-border/50">
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-sm sm:text-base">{translate("OpenAI-spec stream default")}</p>
+                <p className="text-xs sm:text-sm text-text-muted">
+                  {translate("Treat an omitted stream field as non-streaming (issue #4). Off = legacy upstream behavior (omitted = streaming)")}
+                </p>
+              </div>
+              <Toggle
+                checked={settings.strictStreamDefault === true}
+                onChange={toggleStrictStreamDefault}
               />
             </div>
 

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -64,6 +64,9 @@ const DEFAULT_SETTINGS = {
   pxpipeTimeoutMs: 15000,
   // Experimental: auto daily check-in for CodeBuddy CN accounts.
   codeBuddyCheckin: false,
+  // Experimental: OpenAI-spec stream default — omitted `stream` = non-streaming
+  // (issue #4). Default off keeps the upstream-legacy behavior (omitted = streaming).
+  strictStreamDefault: false,
 };
 
 async function readRaw() {

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -284,6 +284,8 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       pxpipeTransform: chatSettings.pxpipeEnabled ? await getPxpipeTransform() : null,
       onPxpipeEvent: appendPxpipeEvent,
       providerThinking,
+      // Issue #4: experimental OpenAI-spec stream default (omitted = non-streaming)
+      strictStreamDefault: !!chatSettings.strictStreamDefault,
       // Detect source format by endpoint + body
       sourceFormatOverride: request?.url ? detectFormatByEndpoint(new URL(request.url).pathname, body) : null,
       onCredentialsRefreshed: async (newCreds) => {

--- a/tests/unit/stream-default.test.js
+++ b/tests/unit/stream-default.test.js
@@ -1,0 +1,56 @@
+/**
+ * Streaming-default resolution (open-sse/utils/streamDefault.js) — issue #4.
+ *
+ * Legacy behavior (toggle off): omitted `stream` means streaming
+ * (`body.stream !== false` — the upstream-inherited default). The
+ * `strictStreamDefault` toggle restores the OpenAI spec: omitted = non-streaming.
+ * `forceStream` providers stream in both modes.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { resolveStreamDefault } from "../../open-sse/utils/streamDefault.js";
+
+describe("resolveStreamDefault (issue #4)", () => {
+  describe("legacy mode (strictStreamDefault: false) — upstream-compatible", () => {
+    const legacy = { providerRequiresStreaming: false, strictStreamDefault: false };
+
+    it("streams when stream is omitted", () => {
+      expect(resolveStreamDefault({ ...legacy, bodyStream: undefined })).toBe(true);
+    });
+
+    it("streams when stream is explicitly true", () => {
+      expect(resolveStreamDefault({ ...legacy, bodyStream: true })).toBe(true);
+    });
+
+    it("does not stream when stream is explicitly false", () => {
+      expect(resolveStreamDefault({ ...legacy, bodyStream: false })).toBe(false);
+    });
+  });
+
+  describe("strict mode (strictStreamDefault: true) — OpenAI spec", () => {
+    const strict = { providerRequiresStreaming: false, strictStreamDefault: true };
+
+    it("does NOT stream when stream is omitted (spec default)", () => {
+      expect(resolveStreamDefault({ ...strict, bodyStream: undefined })).toBe(false);
+    });
+
+    it("streams when stream is explicitly true", () => {
+      expect(resolveStreamDefault({ ...strict, bodyStream: true })).toBe(true);
+    });
+
+    it("does not stream when stream is explicitly false", () => {
+      expect(resolveStreamDefault({ ...strict, bodyStream: false })).toBe(false);
+    });
+  });
+
+  it("forceStream providers stream regardless of mode and request", () => {
+    for (const strictStreamDefault of [false, true]) {
+      for (const bodyStream of [undefined, false, true]) {
+        expect(
+          resolveStreamDefault({ bodyStream, providerRequiresStreaming: true, strictStreamDefault })
+        ).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #4

## 问题

省略 `stream` 字段的 `/v1/chat/completions` 请求被误判为流式：`chatCore.js` 的判定 `body.stream !== false` 在字段省略时恒为真（`undefined !== false`），返回 `text/event-stream` + 尾部 `data: [DONE]` 而非 OpenAI 规范的 `application/json`。官方 SDK / curl / WorkBuddy 等严格 JSON 客户端解析失败。1.0.3 起即存在（上游 9router 继承逻辑，master 未修）。

## 方案：实验性开关（默认关）

行为翻转影响存量客户端（省略 stream 却期待 SSE 的宽松用法），故不做无条件翻转：

- 新增设置键 **`strictStreamDefault`**（Profile → 实验性功能，默认 **关**）
- **关（默认）**：保持现状 —— 省略 = 流式（上游兼容）
- **开**：OpenAI 规范 —— 省略 = 非流式 JSON（`body.stream === true` 才流式）

判定抽为纯函数 `open-sse/utils/streamDefault.js` `resolveStreamDefault`，经 `src/sse/handlers/chat.js` 传入 `handleChatCore`。

## 两档下均不变的行为

- `forceStream` 供应商（openai / codex / codebuddy-cn / codebuddy-intl / commandcode / grok-cli / zed）仍强制流式
- 显式 `Accept: application/json` 回退、deepseek-tui 非交互分支、图像生成非流式分支照旧
- 内部调用方（模型 ping / 供应商测试）本就显式传 `stream: false`，零影响

## 测试

- 新增 `tests/unit/stream-default.test.js`：7 用例锁定两档行为（省略/true/false × 开关 × forceStream）
- 相关测试（free-model、codebuddy-checkin）本地通过；`provider-quota-visibility` 的 `@/` 别名解析失败为本地环境既有问题，与本次改动无关

报告者的临时补丁（编译产物 4 处 `!1!==x.stream` → `!0===x.stream`）已在 WorkBuddy 验证流式+非流式均正常 —— 本 PR 的严格档与其等价。