### PR TITLE
fix(antigravity): propagate forceRefresh to bypass quota summary cache for real-time tracking

### DIFF
--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -33,7 +33,7 @@ import {
 const USAGE_HANDLERS = {
   github: (c) => getGitHubUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
   "gemini-cli": (c) => getGeminiUsage(c.accessToken, c.providerDataWithProjectId, c.proxyOptions),
-  antigravity: (c) => getAntigravityUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
+  antigravity: (c) => getAntigravityUsage(c.accessToken, c.providerSpecificData, c.proxyOptions, { force: c.force }),
   claude: (c) => getClaudeUsage(c.accessToken, c.proxyOptions, { force: c.force }),
   codex: (c) => getCodexUsage(c.accessToken, c.proxyOptions),
   kiro: (c) => getKiroUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),

--- a/open-sse/services/usage/google.js
+++ b/open-sse/services/usage/google.js
@@ -123,7 +123,7 @@ async function getGeminiSubscriptionInfo(accessToken, proxyOptions = null) {
  * account/tier/host, we fall back to the older fetchAvailableModels per-model
  * parsing so the usage page still shows *something*.
  */
-export async function getAntigravityUsage(accessToken, providerSpecificData, proxyOptions = null) {
+export async function getAntigravityUsage(accessToken, providerSpecificData, proxyOptions = null, options = {}) {
   try {
     const subscriptionInfo = await getAntigravitySubscriptionInfo(accessToken, proxyOptions);
     const projectId = subscriptionInfo?.cloudaicompanionProject || null;
@@ -137,7 +137,8 @@ export async function getAntigravityUsage(accessToken, providerSpecificData, pro
           projectId,
           U("antigravity").quotaSummaryApiUrls,
           ANTIGRAVITY_CONFIG.userAgent,
-          proxyOptions
+          proxyOptions,
+          { forceRefresh: options.force === true || options.forceRefresh === true }
         );
         if (summaryQuotas && Object.keys(summaryQuotas).length > 0) {
           return { plan, quotas: summaryQuotas, subscriptionInfo };

--- a/tests/unit/antigravity-quota-summary-hosts.test.js
+++ b/tests/unit/antigravity-quota-summary-hosts.test.js
@@ -108,6 +108,21 @@ describe("Antigravity quota-summary host ordering", () => {
     expect(usage.quotas.gemini_weekly).toMatchObject({ remainingPercentage: 71 });
   });
 
+  it("bypasses cache when forceRefresh is requested", async () => {
+    const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
+
+    await getAntigravityUsage("token-force-refresh-test", {});
+    expect(summaryCalls()).toHaveLength(1);
+
+    // Default call within TTL hits cache (no new network request)
+    await getAntigravityUsage("token-force-refresh-test", {});
+    expect(summaryCalls()).toHaveLength(1);
+
+    // Call with force: true must bypass cache and issue a new request
+    await getAntigravityUsage("token-force-refresh-test", {}, null, { force: true });
+    expect(summaryCalls()).toHaveLength(2);
+  });
+
   it("still answers via the per-model fetchAvailableModels fallback when no summary host responds", async () => {
     summaryHostBehavior.daily = () => jsonResponse(500, {});
     summaryHostBehavior.sandbox = () => jsonResponse(500, {});


### PR DESCRIPTION
## Summary
Follow-up to commit `3c2a370` (dual-window quota summary host fallback):
Propagate `force`/`forceRefresh` to `getAntigravityUsage` and `fetchAndParseAntigravityQuotaSummary`, allowing manual refresh on the dashboard (and calls to `/api/usage/[connectionId]?force=1`) to bypass the 60-second in-memory summary cache (`SUMMARY_CACHE_TTL_MS`) and fetch real-time quota state on demand.

### 🐛 Problem
Commit `3c2a370` brought multi-host fallback (`daily` → `sandbox` → `prod`) aligned with CLIProxyAPI / native IDE. However, `USAGE_HANDLERS.antigravity` in `open-sse/services/usage.js` did not pass `{ force: c.force }` through to `getAntigravityUsage`. As a result, clicking the dashboard refresh button or querying `/api/usage/:id?force=1` still returned the cached snapshot within 60s instead of fetching the latest consumed tokens immediately.

### 🛠️ Changes
1. **`open-sse/services/usage.js`**:
   - Forward `{ force: c.force }` in `USAGE_HANDLERS.antigravity` (matching the existing `claude` pattern).
2. **`open-sse/services/usage/google.js`**:
   - Accept `options` parameter in `getAntigravityUsage`, passing `{ forceRefresh: options.force === true || options.forceRefresh === true }` down to `fetchAndParseAntigravityQuotaSummary`.
3. **`tests/unit/antigravity-quota-summary-hosts.test.js`**:
   - Added unit test verifying that `force: true` successfully bypasses the TTL cache and triggers a fresh upstream network call.

### 🧪 Verification
- `node --check open-sse/services/usage.js` ✅
- `node --check open-sse/services/usage/google.js` ✅
- `npx vitest run tests/unit/antigravity-quota-summary-hosts.test.js` (14 passed) ✅