### PR TITLE
feat(codebuddy-cn): add deepseek-v4.1-flash and render all vision adapter models

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -239,6 +239,7 @@ export const PROVIDER_CAPABILITIES = {
     "kimi-k3-1":          { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 32000 },
     "deepseek-v4-pro":    { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: true, contextWindow: 1000000, maxOutput: 50000 },
     "deepseek-v4-flash":  { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: true, contextWindow: 1000000, maxOutput: 50000 },
+    "deepseek-v4.1-flash": { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: true, contextWindow: 1000000, maxOutput: 50000 },
     "deepseek-v4-flash-vision-exp": { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 384000 },
   },
   // Qoder — upstream exposes opaque internal ids (dfmodel, kmodel, …); the

--- a/open-sse/providers/registry/codebuddy-cn.js
+++ b/open-sse/providers/registry/codebuddy-cn.js
@@ -73,6 +73,7 @@ export default {
     { id: "kimi-k3-1", name: "Kimi-K3 (1)" },
     { id: "deepseek-v4-pro", name: "DeepSeek-V4-Pro" },
     { id: "deepseek-v4-flash", name: "DeepSeek-V4-Flash" },
+    { id: "deepseek-v4.1-flash", name: "DeepSeek-V4.1-Flash" },
   ],
   oauth: {
     baseUrl: "https://copilot.tencent.com",

--- a/providers/codebuddy-cn.json
+++ b/providers/codebuddy-cn.json
@@ -15,6 +15,7 @@
     { "id": "hy3-preview", "name": "Hy3 Preview", "type": "llm", "vision": true, "reasoning": true, "contextWindow": 192000, "maxOutput": 64000, "thinkingFormat": "openai" },
     { "id": "hy4-preview", "name": "Hy4 Preview", "type": "llm", "vision": true, "reasoning": true, "contextWindow": 1000000, "maxOutput": 64000, "thinkingFormat": "openai" },
     { "id": "deepseek-v4-pro", "name": "DeepSeek-V4-Pro", "type": "llm", "vision": true, "reasoning": true, "contextWindow": 1000000, "maxOutput": 50000, "thinkingFormat": "openai" },
-    { "id": "deepseek-v4-flash", "name": "DeepSeek-V4-Flash", "type": "llm", "vision": true, "reasoning": true, "contextWindow": 1000000, "maxOutput": 50000, "thinkingFormat": "openai" }
+    { "id": "deepseek-v4-flash", "name": "DeepSeek-V4-Flash", "type": "llm", "vision": true, "reasoning": true, "contextWindow": 1000000, "maxOutput": 50000, "thinkingFormat": "openai" },
+    { "id": "deepseek-v4.1-flash", "name": "DeepSeek-V4.1-Flash", "type": "llm", "vision": true, "reasoning": true, "contextWindow": 1000000, "maxOutput": 50000, "thinkingFormat": "openai", "enabled": true }
   ]
 }

--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -314,15 +314,12 @@ function ComboCard({ combo, getCaps, activeProviders = [], copied, onCopy, onEdi
               {combo.models.length === 0 ? (
                 <span className="text-xs text-text-muted italic">No models</span>
               ) : (
-                combo.models.slice(0, 3).map((model, index) => (
+                combo.models.map((model, index) => (
                   <code key={index} className="inline-flex items-center gap-1 rounded bg-black/5 px-1.5 py-0.5 font-mono text-xs text-text-muted dark:bg-white/5">
                     <span>{model}</span>
                     <CapacityBadges caps={getCaps?.(model)} />
                   </code>
                 ))
-              )}
-              {combo.models.length > 3 && (
-                <span className="text-[10px] text-text-muted">+{combo.models.length - 3} more</span>
               )}
             </div>
             {/* Fusion: judge picker (Auto = first model) */}
@@ -487,7 +484,7 @@ function CapacityAdapterCap({ cap, entry, onChange, activeProviders, getCaps }) 
               {models.length === 0 ? (
                 <span className="text-xs text-text-muted italic">{translate("No models")}</span>
               ) : (
-                models.slice(0, 3).map((model, index) => (
+                models.map((model, index) => (
                   <code
                     key={`${model}-${index}`}
                     className="group/chip inline-flex items-center gap-1 rounded bg-black/5 px-1.5 py-0.5 font-mono text-xs text-text-muted dark:bg-white/5"
@@ -505,9 +502,6 @@ function CapacityAdapterCap({ cap, entry, onChange, activeProviders, getCaps }) 
                     </button>
                   </code>
                 ))
-              )}
-              {models.length > 3 && (
-                <span className="text-[10px] text-text-muted">+{models.length - 3} {translate("more")}</span>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Description
1. **Support DeepSeek V4.1 Flash in CodeBuddy CN**: Added `deepseek-v4.1-flash` to `providers/codebuddy-cn.json` and `open-sse/providers/registry/codebuddy-cn.js`. Also registered its `vision: true` and `reasoning: true` attributes in `open-sse/providers/capabilities.js` so it avoids unintended fallback in `capacityAdapter.vision`.
2. **Display all models in combos & vision adapter**: Removed hardcoded `.slice(0, 3)` in `src/app/(dashboard)/dashboard/combos/page.js` so all configured models are visible and manageable without unclickable truncated labels.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Configuration update

## Verification
- Verified capability lookup resolves with `{ vision: true, reasoning: true, contextWindow: 1000000 }`.
- Verified `/v1/chat/completions` passes through directly to `deepseek-v4.1-flash` with image input.
- Verified dashboard combos page displays all configured models cleanly.
